### PR TITLE
  [Feature] Adds #release_version method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ version_2.up(:minor).to_s # => '1.2.0-rc.1'
 version_2.up(:major).to_s # => '2.0.0-rc.1'
 version_2.up(:pre_release).to_s # => '1.1.2-rc.3'
 
+version_2.release_version.to_s #=> 1.1.2
+version_1.with_pre_release('rc').to_s #=> 1.1.2-rc.1
+
 ```
 
 ## Development

--- a/lib/vseries/semantic_version.rb
+++ b/lib/vseries/semantic_version.rb
@@ -20,6 +20,10 @@ module Vseries
         instance
       end
 
+      def self.empty
+        new('')
+      end
+
       def initialize(pre_release, initial_number: DEFAULT_PRE_RELEASE_INITIAL_NUMBER)
         name, number = pre_release.match(REGEXP)&.captures
 
@@ -107,6 +111,12 @@ module Vseries
 
       new_version.pre_release = PreRelease.with(name: name)
 
+      new_version
+    end
+
+    def release_version
+      new_version = self.dup
+      new_version.pre_release = PreRelease.empty
       new_version
     end
 

--- a/spec/lib/vseries/semantic_version_spec.rb
+++ b/spec/lib/vseries/semantic_version_spec.rb
@@ -130,4 +130,24 @@ RSpec.describe Vseries::SemanticVersion do
       end
     end
   end
+
+  describe '#release_version' do
+    subject { described_class.new(version).release_version }
+
+    context 'with a pre_release version' do
+      let(:version) { '1.1.2-rc.2' }
+
+      it 'returns the release version' do
+        is_expected.to eq(described_class.new('1.1.2'))
+      end
+    end
+
+    context 'with a release version' do
+      let(:version) { '9.3.2' }
+
+      it 'returns the same version' do
+        is_expected.to eq(described_class.new(version))
+      end
+    end
+  end
 end


### PR DESCRIPTION
  #release_version returns the release version of a pre_release

  Eg: 1.1.2-rc.10 => 1.1.2